### PR TITLE
Fix missing setuptools_scm dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,7 @@ test:
     - python {{ python_min }}
   imports:
     - pyavm
+    - pyavm._version
   commands:
     - pip check
     - pytest $SP_DIR/pyavm -p no:warnings   # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - python {{ python_min }}
     - pip
     - setuptools
+    - setuptools_scm
   run:
     - python >={{ python_min }}
 
@@ -32,7 +33,6 @@ test:
     - python {{ python_min }}
   imports:
     - pyavm
-    - pyavm._version
   commands:
     - pip check
     - pytest $SP_DIR/pyavm -p no:warnings   # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 2
+  number: 3
 
 requirements:
   host:


### PR DESCRIPTION
First adding a check for the _version import, then will fix the issue.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
